### PR TITLE
Add `app_preview_lints` package

### DIFF
--- a/packages/app_preview/analytics_options.yaml
+++ b/packages/app_preview/analytics_options.yaml
@@ -1,1 +1,1 @@
-include: package:lints/recommended.yaml
+include: package:app_preview_lints/analytics_options.yaml

--- a/packages/app_preview/pubspec.yaml
+++ b/packages/app_preview/pubspec.yaml
@@ -2,13 +2,14 @@ name: codemagic_app_preview
 
 environment:
   sdk: ">=2.17.1 <3.0.0"
-  
-dependencies: 
+
+dependencies:
   args: ^2.3.1
   http: ^0.13.4
 
-dev_dependencies: 
-  lints: ^2.0.0
+dev_dependencies:
+  app_preview_lints:
+    path: ../app_preview_lints
   mocktail: ^0.3.0
   test: ^1.21.1
 

--- a/packages/app_preview_lints/.gitignore
+++ b/packages/app_preview_lints/.gitignore
@@ -1,0 +1,41 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release
+
+pubspec.lock

--- a/packages/app_preview_lints/lib/analysis_options.yaml
+++ b/packages/app_preview_lints/lib/analysis_options.yaml
@@ -1,0 +1,11 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    # We want to have sorted imports, to keep our imports clean.
+    - directives_ordering
+
+    # The following lints are for a consistent code style.
+    - sort_constructors_first
+    - prefer_single_quotes
+    - use_super_parameters

--- a/packages/app_preview_lints/pubspec.yaml
+++ b/packages/app_preview_lints/pubspec.yaml
@@ -1,0 +1,8 @@
+name: app_preview_lints
+description: Set of lint rules for for the app preview CLI.
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  lints: ^2.0.0


### PR DESCRIPTION
In `app_preview_lints` we will collect our lint rules. This package can be reused by other local packages, like `app_preview.`