### PR TITLE
Do not escape commit hash with `

### DIFF
--- a/packages/codemagic_app_preview/lib/src/comment/comment_builder.dart
+++ b/packages/codemagic_app_preview/lib/src/comment/comment_builder.dart
@@ -23,7 +23,7 @@ class CommentBuilder {
     final table = _buildTable(builds);
 
     comment.write(
-        '⬇️ Generated builds by [Codemagic]($codemagicBuildUrl) for commit \`$commit\` ⬇️');
+        '⬇️ Generated builds by [Codemagic]($codemagicBuildUrl) for commit $commit ⬇️');
 
     if (message != null) {
       comment.write('\n\n$message');

--- a/packages/codemagic_app_preview/test/comment_builder_test.dart
+++ b/packages/codemagic_app_preview/test/comment_builder_test.dart
@@ -36,7 +36,7 @@ void main() {
       accessor.environmentVariables['FCI_COMMIT'] = commit;
 
       expect(builder.build(builds),
-          """⬇️ Generated builds by [Codemagic](https://codemagic.io/app/$projectId/build/$buildId) for commit \`$commit\` ⬇️
+          """⬇️ Generated builds by [Codemagic](https://codemagic.io/app/$projectId/build/$buildId) for commit $commit ⬇️
 
 | ${builds[0].platform.name} | ${builds[1].platform.name} |
 |:-:|:-:|


### PR DESCRIPTION
Without ` users can click on the commit in GitHub. Makes more sense.