### PR TITLE
feat: decrease Dart SDK minimum from 2.17 to 2.14

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -3,6 +3,9 @@ name: pull-request-ci
 on:
   pull_request:
 
+env:
+  FLUTTER_VERSION: 2.0.0
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -11,7 +14,6 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
 
       - name: Install Melos
         run: dart pub global activate melos
@@ -29,7 +31,6 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
 
       - name: Install Melos
         run: dart pub global activate melos
@@ -47,7 +48,6 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: ${{ env.FLUTTER_CHANNEL }}
 
       - name: Install Melos
         run: dart pub global activate melos

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  FLUTTER_VERSION: 2.0.0
+  FLUTTER_VERSION: 2.5.0
 
 jobs:
   test:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 env:
-  FLUTTER_VERSION: 2.5.0
+  FLUTTER_VERSION: 2.5.0 # Uses Dart SDK v2.14.0
 
 jobs:
   test:

--- a/packages/app_preview_example/lib/main.dart
+++ b/packages/app_preview_example/lib/main.dart
@@ -5,7 +5,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
+  const MyHomePage({Key? key, required this.title}) : super(key: key);
 
   final String title;
 

--- a/packages/app_preview_example/pubspec.lock
+++ b/packages/app_preview_example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -80,14 +80,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.3"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -148,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -162,6 +155,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
 sdks:
   dart: ">=2.14.0 <3.0.0"

--- a/packages/app_preview_example/pubspec.lock
+++ b/packages/app_preview_example/pubspec.lock
@@ -49,14 +49,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,7 +73,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -101,7 +101,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -148,13 +148,20 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.17.5 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/packages/app_preview_example/pubspec.yaml
+++ b/packages/app_preview_example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/app_preview_example/pubspec.yaml
+++ b/packages/app_preview_example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.5 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/app_preview_lints/lib/analysis_options.yaml
+++ b/packages/app_preview_lints/lib/analysis_options.yaml
@@ -8,4 +8,3 @@ linter:
     # The following lints are for a consistent code style.
     - sort_constructors_first
     - prefer_single_quotes
-    - use_super_parameters

--- a/packages/app_preview_lints/pubspec.yaml
+++ b/packages/app_preview_lints/pubspec.yaml
@@ -2,7 +2,7 @@ name: app_preview_lints
 description: Set of lint rules for for the app preview CLI.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   lints: ^1.0.1

--- a/packages/app_preview_lints/pubspec.yaml
+++ b/packages/app_preview_lints/pubspec.yaml
@@ -2,7 +2,7 @@ name: app_preview_lints
 description: Set of lint rules for for the app preview CLI.
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  lints: ^2.0.0
+  lints: ^1.0.1

--- a/packages/codemagic_app_preview/lib/src/builds/build.dart
+++ b/packages/codemagic_app_preview/lib/src/builds/build.dart
@@ -28,7 +28,7 @@ class Build {
   factory Build.fromJson(Map<String, dynamic> json) {
     return Build(
       url: json['url'],
-      platform: BuildPlatform.fromType(json['type']),
+      platform: getBuildPlatform(json['type']),
     );
   }
 

--- a/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
+++ b/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
@@ -17,7 +17,7 @@ enum BuildPlatform {
 /// class, like: https://github.com/nilsreichardt/codemagic-app-preview/blob/8996c2219af619acfb0a37df83e83041202653e4/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
 extension BuildPlatformExtension on BuildPlatform {
   /// Returns the name of the platform, e.g. "iOS" for [ios].
-  String get name {
+  String get platformName {
     switch (this) {
       case BuildPlatform.android:
         return 'Android';

--- a/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
+++ b/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
@@ -13,8 +13,8 @@ enum BuildPlatform {
 
 /// Extension methods for [BuildPlatform].
 ///
-/// When using Dart 2.17 as minimum version, should be refactored to enum class,
-/// like: https://github.com/nilsreichardt/codemagic-app-preview/blob/8996c2219af619acfb0a37df83e83041202653e4/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
+/// When using Dart 2.17 as minimum version, should this be refactored to enum
+/// class, like: https://github.com/nilsreichardt/codemagic-app-preview/blob/8996c2219af619acfb0a37df83e83041202653e4/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
 extension BuildPlatformExtension on BuildPlatform {
   /// Returns the name of the platform, e.g. "iOS" for [ios].
   String get name {

--- a/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
+++ b/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
@@ -9,27 +9,33 @@ enum BuildPlatform {
   ///
   /// File formats are `.ipa`.
   ios;
+}
 
-  factory BuildPlatform.fromType(String type) {
-    switch (type) {
-      // todo: is this really aab or something else?
-      case 'aab':
-      case 'apk':
-        return android;
-      case 'ipa':
-        return ios;
-      default:
-        throw Exception('Unknown build platform type: $type');
-    }
-  }
-
+/// Extension methods for [BuildPlatform].
+///
+/// When using Dart 2.17 as minimum version, should be refactored to enum class,
+/// like: https://github.com/nilsreichardt/codemagic-app-preview/blob/8996c2219af619acfb0a37df83e83041202653e4/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
+extension BuildPlatformExtension on BuildPlatform {
   /// Returns the name of the platform, e.g. "iOS" for [ios].
   String get name {
     switch (this) {
-      case android:
+      case BuildPlatform.android:
         return 'Android';
-      case ios:
+      case BuildPlatform.ios:
         return 'iOS';
     }
+  }
+}
+
+/// Returns the [BuildPlatform] for the given [fileExtension].
+BuildPlatform getBuildPlatform(String fileExtension) {
+  switch (fileExtension) {
+    case 'aab':
+    case 'apk':
+      return BuildPlatform.android;
+    case 'ipa':
+      return BuildPlatform.ios;
+    default:
+      throw Exception('Unknown build platform file extension: $fileExtension');
   }
 }

--- a/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
+++ b/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
@@ -8,7 +8,7 @@ enum BuildPlatform {
   /// The build is for the iOS platform.
   ///
   /// File formats are `.ipa`.
-  ios;
+  ios,
 }
 
 /// Extension methods for [BuildPlatform].

--- a/packages/codemagic_app_preview/lib/src/comment/comment_builder.dart
+++ b/packages/codemagic_app_preview/lib/src/comment/comment_builder.dart
@@ -1,4 +1,5 @@
 import 'package:codemagic_app_preview/src/builds/build.dart';
+import 'package:codemagic_app_preview/src/builds/build_platform.dart';
 import 'package:codemagic_app_preview/src/environment_variable/environment_variable_accessor.dart';
 
 class CommentBuilder {
@@ -50,7 +51,7 @@ class CommentBuilder {
 
     table.write('|');
     for (final build in builds) {
-      table.write(' ${build.platform.name} |');
+      table.write(' ${build.platform.platformName} |');
     }
 
     table.write('\n|');

--- a/packages/codemagic_app_preview/lib/src/comment/comment_poster.dart
+++ b/packages/codemagic_app_preview/lib/src/comment/comment_poster.dart
@@ -20,7 +20,7 @@ class CommentPoster {
     final shouldEdit = previousComment != null;
 
     if (shouldEdit) {
-      await _gitHubApi.editComment(previousComment.id, comment);
+      await _gitHubApi.editComment(previousComment!.id, comment);
     } else {
       await _gitHubApi.postComment(pullRequestId, comment);
     }

--- a/packages/codemagic_app_preview/lib/src/comment/posted_comment.dart
+++ b/packages/codemagic_app_preview/lib/src/comment/posted_comment.dart
@@ -1,14 +1,14 @@
 /// A posted comment from GitHub.
 class PostedComment {
-  const PostedComment(
-    this.id,
-    this.body,
-  );
+  const PostedComment({
+    required this.id,
+    required this.body,
+  });
 
   factory PostedComment.fromJson(Map<String, dynamic> json) {
     return PostedComment(
-      json['id'],
-      json['body'],
+      id: json['id'],
+      body: json['body'],
     );
   }
 

--- a/packages/codemagic_app_preview/pubspec.lock
+++ b/packages/codemagic_app_preview/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "22.0.0"
+    version: "39.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.2"
+    version: "4.0.0"
   app_preview_lints:
     dependency: "direct dev"
     description:
@@ -43,13 +43,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.5"
   collection:
     dependency: transitive
     description:
@@ -85,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
   glob:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.12"
   meta:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
@@ -190,13 +190,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
   pool:
     dependency: transitive
     description:
@@ -224,21 +217,21 @@ packages:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+2"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.4+1"
+    version: "1.0.2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -294,21 +287,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.21.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:

--- a/packages/codemagic_app_preview/pubspec.lock
+++ b/packages/codemagic_app_preview/pubspec.lock
@@ -43,13 +43,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
   cli_util:
     dependency: transitive
     description:
@@ -105,7 +98,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:
@@ -119,7 +112,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.1"
   io:
     dependency: transitive
     description:
@@ -133,7 +126,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   lints:
     dependency: transitive
     description:
@@ -224,7 +217,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.9"
+    version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -359,4 +352,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.16.0-100.0.dev <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/packages/codemagic_app_preview/pubspec.lock
+++ b/packages/codemagic_app_preview/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -345,4 +345,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.1 <3.0.0"
+  dart: ">=2.16.0 <3.0.0"

--- a/packages/codemagic_app_preview/pubspec.lock
+++ b/packages/codemagic_app_preview/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "40.0.0"
+    version: "22.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "1.7.2"
   app_preview_lints:
     dependency: "direct dev"
     description:
@@ -43,6 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.5"
   collection:
     dependency: transitive
     description:
@@ -63,7 +77,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.2"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
@@ -78,13 +92,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
-  frontend_server_client:
-    dependency: transitive
-    description:
-      name: frontend_server_client
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
   glob:
     dependency: transitive
     description:
@@ -98,7 +105,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.12.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -112,7 +119,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "3.1.4"
   io:
     dependency: transitive
     description:
@@ -147,7 +154,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -161,7 +168,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -175,7 +182,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "1.4.13"
   package_config:
     dependency: transitive
     description:
@@ -190,6 +197,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
@@ -210,28 +224,28 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "0.7.9"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "0.2.9+2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "0.2.4+1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -287,21 +301,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.21.1"
+    version: "1.16.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.2.19"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.13"
+    version: "0.3.15"
   typed_data:
     dependency: transitive
     description:
@@ -315,7 +329,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.0"
+    version: "6.2.0"
   watcher:
     dependency: transitive
     description:
@@ -345,4 +359,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.16.0-100.0.dev <3.0.0"

--- a/packages/codemagic_app_preview/pubspec.yaml
+++ b/packages/codemagic_app_preview/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/nilsreichardt/codemagic-app-preview/tree/main/pac
 version: 0.0.1
 
 environment:
-  sdk: ">=2.17.1 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   args: ^2.3.1

--- a/packages/codemagic_app_preview/pubspec.yaml
+++ b/packages/codemagic_app_preview/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
 
 dependencies:
   args: ^2.3.1
-  http: ^0.13.4
+  http: ^0.12.2
 
 dev_dependencies:
   app_preview_lints:
     path: ../app_preview_lints
   mocktail: ^0.3.0
-  test: ^1.21.1
+  test: ^1.16.5
 
 executables:
   app_preview: codemagic_app_preview

--- a/packages/codemagic_app_preview/pubspec.yaml
+++ b/packages/codemagic_app_preview/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   app_preview_lints:
     path: ../app_preview_lints
   mocktail: ^0.3.0
-  test: ^1.16.5
+  test: ^1.21.4
 
 executables:
   app_preview: codemagic_app_preview

--- a/packages/codemagic_app_preview/pubspec.yaml
+++ b/packages/codemagic_app_preview/pubspec.yaml
@@ -4,11 +4,11 @@ repository: https://github.com/nilsreichardt/codemagic-app-preview/tree/main/pac
 version: 0.0.1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   args: ^2.3.1
-  http: ^0.12.2
+  http: ^0.13.4
 
 dev_dependencies:
   app_preview_lints:

--- a/packages/codemagic_app_preview/test/comment_builder_test.dart
+++ b/packages/codemagic_app_preview/test/comment_builder_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(builder.build(builds),
           """⬇️ Generated builds by [Codemagic](https://codemagic.io/app/$projectId/build/$buildId) for commit $commit ⬇️
 
-| ${builds[0].platform.name} | ${builds[1].platform.name} |
+| ${builds[0].platform.platformName} | ${builds[1].platform.platformName} |
 |:-:|:-:|
 | ![image](https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${Uri.encodeComponent(builds[0].url)}) <br /> [Download link](${builds[0].url}) | ![image](https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${Uri.encodeComponent(builds[1].url)}) <br /> [Download link](${builds[1].url}) |
 

--- a/packages/codemagic_app_preview/test/comment_poster_test.dart
+++ b/packages/codemagic_app_preview/test/comment_poster_test.dart
@@ -21,8 +21,8 @@ void main() {
       when(() => gitHubApi.getComments('1')).thenAnswer(
         (_) async => [
           PostedComment(
-            123,
-            'random text <!-- Codemagic App Preview; jobId: default -->',
+            id: 123,
+            body: 'random text <!-- Codemagic App Preview; jobId: default -->',
           ),
         ],
       );


### PR DESCRIPTION
Apps with Flutter 2.x are using Dart 2.14, like [Sharezone](https://github.com/SharezoneApp/sharezone-app). There was no real to use Dart 2.17. So we can just decrease the minimum.