### PR TITLE
feat: support platform macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ publishing:
 ## Supported platforms
 Currently, you can generate a preview only for the following platforms.
 
-| Android | iOS | MacOS | Web | Linux | Windows |
+| Android | iOS | macOS | Web | Linux | Windows |
 | :-----: | :-: | :---: | :-: | :---: | :-----: |
-|   ✔️     | ✔️   |       |     |       |         |
+|   ✔️     | ✔️   |   ✔️   |     |       |         |
 
 ## Disclaimer
 This is an unofficial package for [Codemagic](https://codemagic.io). It's *not* maintained by Codemagic.

--- a/packages/codemagic_app_preview/README.md
+++ b/packages/codemagic_app_preview/README.md
@@ -19,9 +19,9 @@ publishing:
 ## Supported platforms
 Currently, you can generate a preview only for the following platforms.
 
-| Android | iOS | MacOS | Web | Linux | Windows |
+| Android | iOS | macOS | Web | Linux | Windows |
 | :-----: | :-: | :---: | :-: | :---: | :-----: |
-|   ✔️     | ✔️   |       |     |       |         |
+|   ✔️     | ✔️   |   ✔️   |     |       |         |
 
 ## Disclaimer
 This is an unofficial package for [Codemagic](https://codemagic.io). It's *not* maintained by Codemagic.

--- a/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
+++ b/packages/codemagic_app_preview/lib/src/builds/build_platform.dart
@@ -9,6 +9,11 @@ enum BuildPlatform {
   ///
   /// File formats are `.ipa`.
   ios,
+
+  /// The build is for the macOS platform.
+  ///
+  /// File formats are `.app`
+  macos,
 }
 
 /// Extension methods for [BuildPlatform].
@@ -23,6 +28,8 @@ extension BuildPlatformExtension on BuildPlatform {
         return 'Android';
       case BuildPlatform.ios:
         return 'iOS';
+      case BuildPlatform.macos:
+        return 'macOS';
     }
   }
 }
@@ -35,6 +42,8 @@ BuildPlatform getBuildPlatform(String fileExtension) {
       return BuildPlatform.android;
     case 'ipa':
       return BuildPlatform.ios;
+    case 'app':
+      return BuildPlatform.macos;
     default:
       throw Exception('Unknown build platform file extension: $fileExtension');
   }

--- a/packages/codemagic_app_preview/test/comment_builder_test.dart
+++ b/packages/codemagic_app_preview/test/comment_builder_test.dart
@@ -26,6 +26,11 @@ void main() {
               'https://api.codemagic.io/artifacts/2e7564b2-9ffa-40c2-b9e0-8980436ac717/81c5a723-b162-488a-854e-3f5f7fdfb22f/Codemagic_Release.ipa',
           platform: BuildPlatform.ios,
         ),
+        Build(
+          url:
+              'https://api.codemagic.io/artifacts/2e7564b2-9ffa-40c2-b9e0-8980436ac717/81c5a723-b162-488a-854e-3f5f7fdfb22f/Codemagic_Release.zip',
+          platform: BuildPlatform.macos,
+        ),
       ];
 
       final projectId = '6274fcfc87c748ce531c7376';
@@ -38,9 +43,9 @@ void main() {
       expect(builder.build(builds),
           """⬇️ Generated builds by [Codemagic](https://codemagic.io/app/$projectId/build/$buildId) for commit $commit ⬇️
 
-| ${builds[0].platform.platformName} | ${builds[1].platform.platformName} |
-|:-:|:-:|
-| ![image](https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${Uri.encodeComponent(builds[0].url)}) <br /> [Download link](${builds[0].url}) | ![image](https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${Uri.encodeComponent(builds[1].url)}) <br /> [Download link](${builds[1].url}) |
+| ${builds[0].platform.platformName} | ${builds[1].platform.platformName} | ${builds[2].platform.platformName} |
+|:-:|:-:|:-:|
+| ![image](https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${Uri.encodeComponent(builds[0].url)}) <br /> [Download link](${builds[0].url}) | ![image](https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${Uri.encodeComponent(builds[1].url)}) <br /> [Download link](${builds[1].url}) | ![image](https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${Uri.encodeComponent(builds[2].url)}) <br /> [Download link](${builds[2].url}) |
 
 <!-- Codemagic App Preview; jobId: default -->
 """);


### PR DESCRIPTION
<img width="923" alt="image" src="https://user-images.githubusercontent.com/24459435/179380275-123aca28-85db-4565-9220-081e64fa8e2f.png">

With this PR the package supports also macOS apps. macOS apps can be signed with the `MAC_DIRECT` type and installed by download the application via the "Download link" button.