### PR TITLE
ci: fix workflow "validate-pr-title" for fork pull requests

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -24,4 +24,4 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7
         env:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -7,10 +7,10 @@ on:
   # fork.
   pull_request:
     types:
-      - opened
       - synchronize
       - reopened
-      - closed
+      - opened
+      - edited
 
 # Declare default permissions as read only.
 #
@@ -23,3 +23,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -1,0 +1,25 @@
+name: pr-title
+
+on:
+  # Trigger "pull_request" would not work for pull request from a fork because
+  # the secrets would be not accessible. "pull_request_target" uses the context
+  # from the base branch which allows to use secrets for pull requests from a
+  # fork.
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+# Declare default permissions as read only.
+#
+# Having workflows without default permissions is considered a bad security
+# practice and it is causing alerts from our scanning tools.
+permissions: read-all
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -24,4 +24,4 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -84,10 +84,3 @@ jobs:
 
       - name: Verify Pub Score
         run: pana --exit-code-threshold 0
-
-  validate-pr-title:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v1.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We need to use `pull_request_target` instead of `pull_request`

Closes #50 