### PR TITLE
docs: remove adding Dart SDK to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ artifacts:
   - build/macos/Build/Products/Release/*.app
 publishing:
   scripts:
-    # Adding the path to the Dart SDK to PATH to be able to use `dart`
-    # commands and commands of Dart packages. 
-    - name: Add Dart SDK to PATH
-       script: |
-         echo PATH="$PATH":"$FLUTTER_ROOT/.pub-cache/bin" >> $CM_ENV
-         echo PATH="$PATH":"$FLUTTER_ROOT/bin" >> $CM_ENV
      - name: Post App Preview
        script: |
          dart pub global activate codemagic_app_preview

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -41,12 +41,6 @@ workflows:
       - build/macos/Build/Products/Release/*.app # Build output for macOS
     publishing:
       scripts:
-        # Adding the path to the Dart SDK to PATH to be able to use `dart`
-        # commands and commands of Dart packages.
-        - name: Add Dart SDK to PATH
-          script: |
-            echo PATH="$PATH":"$FLUTTER_ROOT/.pub-cache/bin" >> $CM_ENV
-            echo PATH="$PATH":"$FLUTTER_ROOT/bin" >> $CM_ENV
         - name: Post App Preview
           script: |
             # You should use for app the following line instead of "dart pub

--- a/packages/codemagic_app_preview/example/README.md
+++ b/packages/codemagic_app_preview/example/README.md
@@ -41,12 +41,6 @@ workflows:
       - build/macos/Build/Products/Release/*.app # Build output for macOS
     publishing:
       scripts:
-        # Adding the path to the Dart SDK to PATH to be able to use `dart`
-        # commands and commands of Dart packages.
-        - name: Add Dart SDK to PATH
-          script: |
-            echo PATH="$PATH":"$FLUTTER_ROOT/.pub-cache/bin" >> $CM_ENV
-            echo PATH="$PATH":"$FLUTTER_ROOT/bin" >> $CM_ENV
         - name: Post App Preview
           script: |
             dart pub global activate codemagic_app_preview


### PR DESCRIPTION
Since today, the paths to the Dart SDK are in by default available: https://github.com/orgs/codemagic-ci-cd/discussions/1058#discussioncomment-4075628