### PR TITLE
feat(codemagic_app_preview): only built when the pull request has a specific label

### DIFF
--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -1,3 +1,7 @@
+# This is an example of how to use the app previews only when a PR is labeled
+# with "build-app-preview". This is useful if you want to save build minutes and
+# only build the app preview when you want to.
+
 name: App Preview (only with with label)
 
 on:
@@ -9,11 +13,31 @@ on:
 
 jobs:
   label_app_preview:
+    # Only run this job if the PR is labeled with "build-app-preview".
+    #
+    # You can use any label you want. Just make sure to change the label name in
+    # the if condition.
+    #
+    # Keep in mind that a new build will be triggered when the PR is labeled
+    # with any lable as long as the label "build-app-preview" is included in the
+    # list of labels. For example, if the PR is labeled with "build-app-preview"
+    # and "bug", the job will be triggered when the label "bug" is removed.
     if: contains(github.event.pull_request.labels.*.name, 'build-app-preview')
     runs-on: ubuntu-latest
     env:
+      # Access token for the Codemagic API.
+      #
+      # The access token is available in the Codemagic UI under Teams > Personal
+      # Account > Integrations > Codemagic API > Show.
       CODEMAGIC_TOKEN: ${{ secrets.CODEMAGIC_TOKEN }}
+      
+      # This is the ID of the app in Codemagic.
+      #
+      # You can find the ID of your app in the URL of the app in Codemagic.
       CODEMAGIC_APP_ID: "62d2f58c726fce097e34c0b4"
+
+      # This is the ID of the workflow in Codemagic. You might have a different
+      # workflow for building the app preview.
       CODEMAGIC_WORKFLOW_ID: "app_preview"
     steps:
       - name: Start Codemagic Build
@@ -22,7 +46,8 @@ jobs:
           PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d / -f 3)
 
           curl --request POST 'https://api.codemagic.io/builds' \
-            --header 'x-auth-token: $CODEMAGIC_TOKEN' \
+            -f \
+            --header 'x-auth-token: '"$CODEMAGIC_TOKEN" \
             --header 'Content-Type: application/json' \
             --data-raw '{
                 "appId": $CODEMAGIC_APP_ID,
@@ -34,4 +59,3 @@ jobs:
                     }
                 }
             }' \
-            -f

--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -9,8 +9,7 @@ on:
 
 jobs:
   label_app_preview:
-    # Only run this job if the label "build-app-preview" is added to the PR.
-    if: ${{ github.event.label.name == 'build-app-preview' }}
+    if: contains(github.event.pull_request.labels.*.name, 'build-app-preview')
     runs-on: ubuntu-latest
     env:
       CODEMAGIC_TOKEN: ${{ secrets.CODEMAGIC_TOKEN }}

--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -46,16 +46,15 @@ jobs:
           PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d / -f 3)
 
           curl --request POST 'https://api.codemagic.io/builds' \
-            -f \
             --header 'x-auth-token: '"$CODEMAGIC_TOKEN" \
             --header 'Content-Type: application/json' \
-            --data-raw '{
-                "appId": $CODEMAGIC_APP_ID,
-                "branch": $GITHUB_HEAD_REF,
-                "workflowId": $CODEMAGIC_WORKFLOW_ID,
-                "environment": {
-                    "variables": {
-                        "CM_PULL_REQUEST_NUMBER": $PULL_REQUEST_NUMBER,
+            --data-raw "{
+                \"appId\": \"$CODEMAGIC_APP_ID\",
+                \"branch\": \"$GITHUB_HEAD_REF\",
+                \"workflowId\": \"$CODEMAGIC_WORKFLOW_ID\",
+                \"environment\": {
+                    \"variables\": {
+                        \"CM_PULL_REQUEST_NUMBER\": $PULL_REQUEST_NUMBER
                     }
                 }
-            }' \
+            }"

--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -1,6 +1,9 @@
 # This is an example of how to use the app previews only when a PR is labeled
 # with "build-app-preview". This is useful if you want to save build minutes and
 # only build the app preview when you want to.
+#
+# When you use this option, you should remove the "triggering" section from the
+# codemagic.yaml. Otherwise, the app preview will be built twice.
 
 name: App Preview (only with with label)
 
@@ -46,6 +49,7 @@ jobs:
           PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d / -f 3)
 
           curl --request POST 'https://api.codemagic.io/builds' \
+            -f \
             --header 'x-auth-token: '"$CODEMAGIC_TOKEN" \
             --header 'Content-Type: application/json' \
             --data-raw "{

--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -1,4 +1,4 @@
-name: Label App Preview
+name: App Preview (only with with label)
 
 on:
   pull_request:
@@ -22,7 +22,7 @@ jobs:
           # Get the pull request number from the GITHUB_REF.
           PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d / -f 3)
 
-          curl --location --request POST 'https://api.codemagic.io/builds' \
+          curl --request POST 'https://api.codemagic.io/builds' \
             --header 'x-auth-token: $CODEMAGIC_TOKEN' \
             --header 'Content-Type: application/json' \
             --data-raw '{
@@ -34,4 +34,5 @@ jobs:
                         "CM_PULL_REQUEST_NUMBER": $PULL_REQUEST_NUMBER,
                     }
                 }
-            }'
+            }' \
+            -f

--- a/.github/workflows/label_app_preview.yaml
+++ b/.github/workflows/label_app_preview.yaml
@@ -1,0 +1,37 @@
+name: Label App Preview
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+
+jobs:
+  label_app_preview:
+    # Only run this job if the label "build-app-preview" is added to the PR.
+    if: ${{ github.event.label.name == 'build-app-preview' }}
+    runs-on: ubuntu-latest
+    env:
+      CODEMAGIC_TOKEN: ${{ secrets.CODEMAGIC_TOKEN }}
+      CODEMAGIC_APP_ID: "62d2f58c726fce097e34c0b4"
+      CODEMAGIC_WORKFLOW_ID: "app_preview"
+    steps:
+      - name: Start Codemagic Build
+        run: |
+          # Get the pull request number from the GITHUB_REF.
+          PULL_REQUEST_NUMBER=$(echo $GITHUB_REF | cut -d / -f 3)
+
+          curl --location --request POST 'https://api.codemagic.io/builds' \
+            --header 'x-auth-token: $CODEMAGIC_TOKEN' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+                "appId": $CODEMAGIC_APP_ID,
+                "branch": $GITHUB_HEAD_REF,
+                "workflowId": $CODEMAGIC_WORKFLOW_ID,
+                "environment": {
+                    "variables": {
+                        "CM_PULL_REQUEST_NUMBER": $PULL_REQUEST_NUMBER,
+                    }
+                }
+            }'

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -18,12 +18,6 @@ workflows:
       cancel_previous_builds: true
     working_directory: packages/app_preview_example
     scripts:
-      - name: Variables
-        script: |
-          echo "CM_PULL_REQUEST_NUMBER: $CM_PULL_REQUEST_NUMBER"
-          echo "FCI_PROJECT_ID: $FCI_PROJECT_ID"
-          echo "FCI_BUILD_ID: $FCI_BUILD_ID"
-          echo "FCI_COMMIT: $FCI_COMMIT"
       - name: Fetch dependencies
         script: flutter pub get
       - name: Build APK (Android)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -18,13 +18,12 @@ workflows:
       cancel_previous_builds: true
     working_directory: packages/app_preview_example
     scripts:
-      - name: Print GitHub Pull Request data
+      - name: Variables
         script: |
-          curl \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_PAT"\
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/nilsreichardt/codemagic-app-preview/pulls/59 |jq
+          echo "CM_PULL_REQUEST_NUMBER: $CM_PULL_REQUEST_NUMBER"
+          echo "FCI_PROJECT_ID: $FCI_PROJECT_ID"
+          echo "FCI_BUILD_ID: $FCI_BUILD_ID"
+          echo "FCI_COMMIT: $FCI_COMMIT"
       - name: Fetch dependencies
         script: flutter pub get
       - name: Build APK (Android)

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -18,6 +18,13 @@ workflows:
       cancel_previous_builds: true
     working_directory: packages/app_preview_example
     scripts:
+      - name: Print GitHub Pull Request data
+        script: |
+          curl \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_PAT"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/nilsreichardt/codemagic-app-preview/pulls/59 |jq
       - name: Fetch dependencies
         script: flutter pub get
       - name: Build APK (Android)


### PR DESCRIPTION
This PR shows an example how you can configure a GitHub action that starts the Codemagic App Preview build only when the PR has the label "build-app-preview".