### PR TITLE
ci(*): remove pull_request trigger

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -16,8 +16,6 @@ workflows:
         # Adding environment group "appstore_credentials" to sign iOS apps.
         - appstore_credentials
     triggering:
-      events:
-        - pull_request
       cancel_previous_builds: true
     working_directory: packages/app_preview_example
     when:


### PR DESCRIPTION
We should only trigger builds with the `build-app-preview` label, so that we can review the code before it is run.